### PR TITLE
Fix tests on Fedora.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,6 +14,28 @@ env:
     PERL_CARTON_PATH: $GITHUB_WORKSPACE/local
 
 jobs:
+  Linux-fedora:
+    runs-on: ubuntu-latest
+
+    container:
+      image: fedora
+
+    steps:
+      - uses: actions/checkout@main
+      - run: dnf install -y perl-App-cpanminus
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: cpanm --notest --installdeps --with-configure --with-recommends --with-develop --verbose .
+      - name: Install Version-Dependent Optionals
+        run: cpanm --notest Mojolicious
+      - name: perl Makefile.PL
+        run: perl Makefile.PL
+      - name: make
+        run: make
+      - name: Run Tests
+        run: prove -wlvm t
+
   linux:
     runs-on: ubuntu-latest
 

--- a/cpanfile
+++ b/cpanfile
@@ -26,6 +26,9 @@ on test => sub {
     recommends 'IO::Async';
     recommends 'IPC::Run';
 
+    recommends 'HTTP::Request';
+    recommends 'HTTP::Response';
+
     # We omit Mojolicious because it requires a newer Perl version
     # than we do.
 };


### PR DESCRIPTION
Issue #8: Previously our mock cpsrvd would shutdown(SHUT_RD), write the HTTP response, drain the read buffer, then close().

Apparently Net::SSLeay and/or OpenSSL don’t like all that activity after a shutdown() because both the write and close trigger failures on Fedora 36. (And possibly earlier?)

The fix here a) delays the shutdown until we’ve written the HTTP response, and b) omits the manual close().

Additionally, the cpanfile now recommends HTTP::R* modules for testing, and we now do CI against the latest Fedora.